### PR TITLE
feat: DB 연동 설정코드 추가

### DIFF
--- a/manorgass/api/app.py
+++ b/manorgass/api/app.py
@@ -1,5 +1,21 @@
 from flask import Flask, request, jsonify
 from flask.json import JSONEncoder
+from sqlalchemy import create_engine, text
+
+
+def create_app(test_config=None):
+    app = Flask(__name__)
+
+    if test_config is None:
+        app.config.from_pyfile("config.py")
+    else:
+        app.config.update(test_config)
+
+    database = create_engine(
+        app.config['DB_URL'], encoding='utf-8', max_overflow=0)
+    app.database = database
+
+    return app
 
 
 class CustomJSONEncoder(JSONEncoder):

--- a/manorgass/api/config.py
+++ b/manorgass/api/config.py
@@ -1,0 +1,8 @@
+db = {
+    'user': 'root',
+    'password': 'root',
+    'host': 'localhost',
+    'port': 3306,
+    'database': 'miniter'
+}
+DB_URL=f"mysql+mysqlconnector://{db['user']}:{db['password']}@{db['host']}:{db['port']}/{db['database']}?charset=utf8"

--- a/manorgass/sql_query
+++ b/manorgass/sql_query
@@ -1,0 +1,31 @@
+-- miniter table create quary
+
+CREATE TABLE users(
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    hashed_password VARCHAR(255) NOT NULL,
+    profile VARCHAR(2000) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY email (email)
+);
+
+CREATE TABLE users_follow_list(
+    user_id INT NOT NULL,
+    follow_user_id INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, follow_user_id),
+    CONSTRAINT users_follow_list_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT users_follow_list_follow_user_id_fkey FOREIGN KEY (follow_user_id) REFERENCES users(id)
+);
+
+CREATE TABLE tweets(
+    id INT NOT NULL AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    tweet VARCHAR(300) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT tweets_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id)
+);


### PR DESCRIPTION
## Description

- page 159 까지 예제코드 구현.
- DB 연동을 위한 설정 초기화 로직 추가.

<br>

## Key Changes

- import `sqlalchemy`

<br>

## To Reviewers

- NM
